### PR TITLE
upgrade com.google.protobuf:protoc:exe dependency

### DIFF
--- a/integration/grpc/pom.xml
+++ b/integration/grpc/pom.xml
@@ -32,7 +32,6 @@
     <name>seata-grpc ${project.version}</name>
     <description>gRPC integration for Seata built with Maven</description>
 
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -83,9 +82,9 @@
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.11.0:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.22.3:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.27.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.54.0:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>
@@ -99,4 +98,33 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Profile for x86 architecture -->
+        <profile>
+            <id>x86_64</id>
+            <activation>
+                <property>
+                    <name>os.arch</name>
+                    <value>x86_64</value>
+                </property>
+            </activation>
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>
+            </properties>
+        </profile>
+
+        <!-- Since there is no ARM version of protobuf, the x86 version is used forcibly. -->
+        <profile>
+            <id>aarch64</id>
+            <activation>
+                <property>
+                    <name>os.arch</name>
+                    <value>aarch64</value>
+                </property>
+            </activation>
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/serializer/seata-serializer-protobuf/pom.xml
+++ b/serializer/seata-serializer-protobuf/pom.xml
@@ -57,7 +57,7 @@
                 <configuration>
                     <protoSourceRoot>${project.basedir}/src/main/resources/protobuf/org/apache/seata/protocol/transcation/</protoSourceRoot>
                     <protocArtifact>
-                        com.google.protobuf:protoc:3.11.0:exe:${os.detected.classifier}
+                        com.google.protobuf:protoc:3.22.3:exe:${os.detected.classifier}
                     </protocArtifact>
                 </configuration>
                 <executions>
@@ -70,4 +70,34 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Profile for x86 architecture -->
+        <profile>
+            <id>x86_64</id>
+            <activation>
+                <property>
+                    <name>os.arch</name>
+                    <value>x86_64</value>
+                </property>
+            </activation>
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>
+            </properties>
+        </profile>
+
+        <!-- Since there is no ARM version of protobuf, the x86 version is used forcibly. -->
+        <profile>
+            <id>aarch64</id>
+            <activation>
+                <property>
+                    <name>os.arch</name>
+                    <value>aarch64</value>
+                </property>
+            </activation>
+            <properties>
+                <os.detected.classifier>osx-x86_64</os.detected.classifier>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did
upgrade com.google.protobuf:protoc:exe dependency
Because Protobuf does not have an ARM version, according to the experience of other communities, the x86 version can only be forcibly used to compile and build properly. And Google doesn't seem to have the intention of fixing, the protobuf community has issues and PRs about Apple Sicilion chips not compiling, but the community has not responded in any way.



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
#6789

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
unnecessary

### Ⅳ. Describe how to verify it
unnecessary

### Ⅴ. Special notes for reviews
unnecessary
